### PR TITLE
Create the dir tree before starting the container

### DIFF
--- a/jupyter_spinup_lab.sh
+++ b/jupyter_spinup_lab.sh
@@ -1,9 +1,13 @@
+#!/usr/bin/env bash
+set -u
+
 portnr=${1:-9020}
 
 echo "Starting Jupyter server @ port $portnr."
 echo "Command:    jupyter lab --ip 0.0.0.0 --no-browser --port $portnr"
 echo "Kill via:   jupyter notebook stop $portnr"
 
+cd "$WORKDIR"
 nohup jupyter lab --ip 0.0.0.0 --no-browser --port "$portnr" &
 sleep 3.
 jupyter notebook list

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,12 +1,30 @@
-echo "Mapping all ports."
-docker run -it \
+#!/usr/bin/env bash
+set -u
+
+# Configure the mountpoints so that the shared datadir is visible from the
+# user's work directory.
+WORKDIR_HOST="/local/work/nvidia-workshop-2022-04/user/$LOGNAME"
+DATADIR_HOST="/local/work/nvidia-workshop-2022-04/dataset"
+WORKDIR_CONTAINER="/workspace"
+DATADIR_CONTAINER="$WORKDIR_CONTAINER/dataset"
+
+# Export the repository working copy into the work directory.
+REPODIR="$(dirname "$0")"
+mkdir -p "$WORKDIR_HOST/NVIDIA_IKIM_Workshop" \
+    && cp -aR "$REPODIR"/* "$WORKDIR_HOST/NVIDIA_IKIM_Workshop/"
+
+# Start the container.
+docker run --rm -it \
     --gpus all \
     --shm-size=4g \
     --ulimit memlock=-1 \
     --ulimit stack=67108864 \
     --user root \
-	--env SPLEEN_TAR_URL=file:////data/Projects/Essen_Workshop/sources/data/Task09_Spleen.tar \
-    -v /data:/data \
+	--workdir="$WORKDIR_CONTAINER" \
+	--env WORKDIR="$WORKDIR_CONTAINER" \
+	--env DATADIR="$DATADIR_CONTAINER" \
+    -v "$WORKDIR_HOST":"$WORKDIR_CONTAINER" \
+    -v "$DATADIR_HOST":"$DATADIR_CONTAINER" \
     --network=host \
-    --name essen_workshop \
+    --name "essen_workshop_$LOGNAME" \
     projectmonai/monai:latest


### PR DESCRIPTION
The container now starts from a user-specific work directory populated with the necessary inputs, exercises and scripts.

I haven't adapted the jupyter notebooks to the new environment variables. I'll do that asap.