### PR TITLE
Mount DATADIR read-only to avoid accidents

### DIFF
--- a/start_docker.sh
+++ b/start_docker.sh
@@ -24,7 +24,7 @@ docker run --rm -it \
 	--env WORKDIR="$WORKDIR_CONTAINER" \
 	--env DATADIR="$DATADIR_CONTAINER" \
     -v "$WORKDIR_HOST":"$WORKDIR_CONTAINER" \
-    -v "$DATADIR_HOST":"$DATADIR_CONTAINER" \
+    -v "$DATADIR_HOST":"$DATADIR_CONTAINER":ro \
     --network=host \
     --name "essen_workshop_$LOGNAME" \
     projectmonai/monai:latest


### PR DESCRIPTION
Users are supposed to write only in WORKDIR.